### PR TITLE
added logic to calculate datetime of trial starts and whether correction trial

### DIFF
--- a/ephys/core.py
+++ b/ephys/core.py
@@ -6,6 +6,9 @@ import h5py as h5
 import pandas as pd
 from functools import wraps
 
+try: import simplejson as json
+except ImportError: import json
+
 def file_finder(find_file_func):
     '''
     Decorator to help find files.
@@ -264,3 +267,8 @@ def load_spikes(block_path,channel_group=0,clustering='main'):
                  )
             )
     return spikes
+
+def load_info(block_path):
+    with open(find_info(block_path)) as f:
+        info = json.load(f)
+    return info

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,28 @@
+import unittest
+import datetime as dt
+import numpy as np
+from ephys import events
+
+
+class EventTest(unittest.TestCase):
+
+    def test_is_not_floatable(self):
+        assert events._is_not_floatable(3.0)==False
+        assert events._is_not_floatable('I love lamp')==True
+
+    def test_is_correct(self):
+        assert events.is_correct('F')==True
+        assert events.is_correct('f')==True
+        assert events.is_correct('T')==False
+        assert np.isnan(events.is_correct(np.nan))
+
+    def test_calc_rec_datetime(self):
+        file_origin = '/mnt/cube/justin/matfiles/Pen01_Lft_AP2500_ML1350__Site04_Z1466__B997_cat_P01_S04_Epc01-03/SubB997Pen01Site04Epc02File01_10-25-15+12-46-08_B997_block.mat'
+        start_time = 4.8e-05
+        assert events.calc_rec_datetime(file_origin,start_time)==dt.datetime(2015, 10, 25, 12, 46, 8, 48)
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
this pull request adds two features:

- each trial gets a datetime that is calculated from the recording metadata (in the info json file) and the time_samples of the trial
- each trial gets a 'correction' column which computes whether the trial was a correction trial (might need to think through the edge cases here better)